### PR TITLE
Manually verify the JWT issuer

### DIFF
--- a/spec/omniauth/strategies/google_oauth2_spec.rb
+++ b/spec/omniauth/strategies/google_oauth2_spec.rb
@@ -313,35 +313,60 @@ describe OmniAuth::Strategies::GoogleOauth2 do
     before { allow(subject).to receive(:access_token).and_return(access_token) }
 
     describe 'id_token' do
-      context 'when the id_token is passed into the access token' do
-        token_info =
+      shared_examples 'id_token issued by valid issuer' do |issuer| # rubocop:disable Metrics/BlockLength
+        context 'when the id_token is passed into the access token' do
+          let(:token_info) do
+            {
+              'abc' => 'xyz',
+              'exp' => Time.now.to_i + 3600,
+              'nbf' => Time.now.to_i - 60,
+              'iat' => Time.now.to_i,
+              'aud' => 'appid',
+              'iss' => issuer
+            }
+          end
+          let(:id_token) { JWT.encode(token_info, 'secret') }
+          let(:access_token) { OAuth2::AccessToken.from_hash(client, 'id_token' => id_token) }
+
+          it 'should include id_token when set on the access_token' do
+            expect(subject.extra).to include(id_token: id_token)
+          end
+
+          it 'should include id_info when id_token is set on the access_token and skip_jwt is false' do
+            subject.options[:skip_jwt] = false
+            expect(subject.extra).to include(id_info: token_info)
+          end
+
+          it 'should not include id_info when id_token is set on the access_token and skip_jwt is true' do
+            subject.options[:skip_jwt] = true
+            expect(subject.extra).not_to have_key(:id_info)
+          end
+
+          it 'should include id_info when id_token is set on the access_token by default' do
+            expect(subject.extra).to include(id_info: token_info)
+          end
+        end
+      end
+
+      it_behaves_like 'id_token issued by valid issuer', 'accounts.google.com'
+      it_behaves_like 'id_token issued by valid issuer', 'https://accounts.google.com'
+
+      context 'when the id_token is issued by an invalid issuer' do
+        let(:token_info) do
           {
             'abc' => 'xyz',
             'exp' => Time.now.to_i + 3600,
             'nbf' => Time.now.to_i - 60,
             'iat' => Time.now.to_i,
             'aud' => 'appid',
-            'iss' => 'accounts.google.com'
+            'iss' => 'fake.google.com'
           }
-        id_token = JWT.encode(token_info, 'secret')
+        end
+        let(:id_token) { JWT.encode(token_info, 'secret') }
         let(:access_token) { OAuth2::AccessToken.from_hash(client, 'id_token' => id_token) }
 
-        it 'should include id_token when set on the access_token' do
-          expect(subject.extra).to include(id_token: id_token)
-        end
-
-        it 'should include id_info when id_token is set on the access_token and skip_jwt is false' do
-          subject.options[:skip_jwt] = false
-          expect(subject.extra).to include(id_info: token_info)
-        end
-
-        it 'should not include id_info when id_token is set on the access_token and skip_jwt is true' do
-          subject.options[:skip_jwt] = true
-          expect(subject.extra).not_to have_key(:id_info)
-        end
-
-        it 'should include id_info when id_token is set on the access_token by default' do
-          expect(subject.extra).to include(id_info: token_info)
+        it 'raises JWT::InvalidIssuerError' do
+          expect { subject.extra }.to raise_error(JWT::InvalidIssuerError)
         end
       end
 


### PR DESCRIPTION
Per https://developers.google.com/identity/sign-in/web/backend-auth:

> The value of iss in the ID token is equal to accounts.google.com or https://accounts.google.com.

The JWT decoder **should** be verifying that the `iss` is either one of
those values. In ruby-jwt 1.5.6, only one issuer can be supplied
(https://github.com/jwt/ruby-jwt/blob/8e8a9c9f9fd455537c03b6dcde1e20ebbc1fe585/lib/jwt/verify.rb#L62).

However, in ruby-jwt v2.0+, this can be an array:
https://github.com/jwt/ruby-jwt/commit/ed3a6483b4e81314ca2e7168701a9d34afcb690d

To preserve compatibility with ruby-jwt 1.5.6 and 2.0, manually check the issuer is
one of the valid ones.