### PR TITLE
Verify multiple Google issuers and fix JWT claim verifications

### DIFF
--- a/lib/omniauth/strategies/google_oauth2.rb
+++ b/lib/omniauth/strategies/google_oauth2.rb
@@ -8,6 +8,7 @@ module OmniAuth
   module Strategies
     # Main class for Google OAuth2 strategy.
     class GoogleOauth2 < OmniAuth::Strategies::OAuth2
+      ALLOWED_ISSUERS = ['accounts.google.com', 'https://accounts.google.com'].freeze
       BASE_SCOPE_URL = 'https://www.googleapis.com/auth/'
       BASE_SCOPES = %w[profile email openid].freeze
       DEFAULT_SCOPE = 'email,profile'
@@ -59,18 +60,23 @@ module OmniAuth
         hash = {}
         hash[:id_token] = access_token['id_token']
         if !options[:skip_jwt] && !access_token['id_token'].nil?
-          hash[:id_info] = ::JWT.decode(
-            access_token['id_token'], nil, false, verify_iss: options.verify_iss,
-                                                  iss: 'accounts.google.com',
-                                                  verify_aud: true,
-                                                  aud: options.client_id,
-                                                  verify_sub: false,
-                                                  verify_expiration: true,
-                                                  verify_not_before: true,
-                                                  verify_iat: true,
-                                                  verify_jti: false,
-                                                  leeway: options[:jwt_leeway]
-          ).first
+          decoded = ::JWT.decode(access_token['id_token'], nil, false).first
+
+          # We have to manually verify the claims because the third parameter to
+          # JWT.decode is false since no verification key is provided.
+          ::JWT::Verify.verify_claims(decoded,
+                                      verify_iss: true,
+                                      iss: ALLOWED_ISSUERS,
+                                      verify_aud: true,
+                                      aud: options.client_id,
+                                      verify_sub: false,
+                                      verify_expiration: true,
+                                      verify_not_before: true,
+                                      verify_iat: true,
+                                      verify_jti: false,
+                                      leeway: options[:jwt_leeway])
+
+          hash[:id_info] = decoded
         end
         hash[:raw_info] = raw_info unless skip_info?
         hash[:raw_friend_info] = raw_friend_info(raw_info['sub']) unless skip_info? || options[:skip_friends]

--- a/omniauth-google-oauth2.gemspec
+++ b/omniauth-google-oauth2.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
 
   gem.required_ruby_version = '>= 2.1'
 
-  gem.add_runtime_dependency 'jwt', '>= 1.5'
+  gem.add_runtime_dependency 'jwt', '>= 2.0'
   gem.add_runtime_dependency 'omniauth', '>= 1.1.1'
   gem.add_runtime_dependency 'omniauth-oauth2', '>= 1.5'
 


### PR DESCRIPTION
Per https://developers.google.com/identity/sign-in/web/backend-auth:

> The value of iss in the ID token is equal to accounts.google.com or https://accounts.google.com.

The JWT decoder **should** be verifying that the `iss` is either one of
those values. In ruby-jwt 1.5.6, only one issuer can be supplied
(https://github.com/jwt/ruby-jwt/blob/8e8a9c9f9fd455537c03b6dcde1e20ebbc1fe585/lib/jwt/verify.rb#L62).

However, in ruby-jwt v2.0+, this can be an array:
https://github.com/jwt/ruby-jwt/commit/ed3a6483b4e81314ca2e7168701a9d34afcb690d